### PR TITLE
update match pattern

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -16,7 +16,7 @@
     "content_scripts": [
         {
             "matches": [
-                "https://engage.streaming.rwth-aachen.de/paella/ui/watch.html**"
+                "https://engage.streaming.rwth-aachen.de/*paella/ui/watch.html**"
             ],
             "all_frames": true,
             "js": [


### PR DESCRIPTION
The player is currently loaded using URLs of this scheme: "https://engage.streaming.rwth-aachen.de//paella/[...]"
I had to change the match pattern in order to still catch them. I also left it as vague as possible, in case the current changes are reverted in the future.